### PR TITLE
feat: add AI-powered PR reviewer for pull requests

### DIFF
--- a/.github/workflows/ai-review.yml
+++ b/.github/workflows/ai-review.yml
@@ -1,0 +1,182 @@
+name: AI Code Review
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+    branches: [main]
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  ai-review:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check API key
+        id: check-key
+        env:
+          HAS_KEY: ${{ secrets.ANTHROPIC_API_KEY != '' }}
+        run: |
+          if [ "$HAS_KEY" != "true" ]; then
+            echo "ANTHROPIC_API_KEY not configured. Skipping AI review."
+            echo "skip=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "skip=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Checkout code
+        if: steps.check-key.outputs.skip != 'true'
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+
+      - name: Get PR diff
+        id: diff
+        if: steps.check-key.outputs.skip != 'true'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          DIFF=$(gh pr diff "${{ github.event.pull_request.number }}" || echo "")
+
+          if [ -z "$DIFF" ]; then
+            echo "skip=true" >> "$GITHUB_OUTPUT"
+            echo "No diff found, skipping review."
+            exit 0
+          fi
+
+          # Truncate if too large
+          DIFF_LEN=${#DIFF}
+          TRUNCATED="false"
+          if [ "$DIFF_LEN" -gt 15000 ]; then
+            DIFF="${DIFF:0:15000}"
+            TRUNCATED="true"
+          fi
+
+          echo "skip=false" >> "$GITHUB_OUTPUT"
+          echo "truncated=$TRUNCATED" >> "$GITHUB_OUTPUT"
+
+          # Write diff to file for safe handling (avoids shell escaping issues)
+          printf '%s' "$DIFF" > /tmp/pr_diff.txt
+
+      - name: Call Claude API for review
+        id: review
+        if: steps.check-key.outputs.skip != 'true' && steps.diff.outputs.skip != 'true'
+        env:
+          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+          PR_TITLE: ${{ github.event.pull_request.title }}
+          PR_BODY: ${{ github.event.pull_request.body }}
+          TRUNCATED: ${{ steps.diff.outputs.truncated }}
+        run: |
+          set -euo pipefail
+
+          DIFF=$(cat /tmp/pr_diff.txt)
+
+          TRUNC_NOTE=""
+          if [ "$TRUNCATED" = "true" ]; then
+            TRUNC_NOTE="NOTE: The diff was truncated to 15,000 characters. Some changes may not be included in this review."
+          fi
+
+          # Build JSON payload safely with jq
+          PAYLOAD=$(jq -n \
+            --arg model "claude-sonnet-4-6" \
+            --arg system "You are an expert code reviewer specializing in Go microservices, Kubernetes operators, Terraform infrastructure, Helm charts, and GitHub Actions CI/CD pipelines. Review the provided PR diff and provide structured feedback. Format your response EXACTLY as follows:
+
+          ## AI Code Review
+
+          ### Summary
+          <2-3 sentence summary of what the PR does>
+
+          ### Security
+          <security findings or No security concerns found>
+
+          ### Correctness
+          <logic issues, edge cases, potential bugs>
+
+          ### Test Coverage
+          <test gaps or Tests look adequate>
+
+          ### Style & Best Practices
+          <code quality observations>
+
+          ### Suggestions
+          <numbered list of actionable improvements>
+
+          ---
+          *Reviewed by Claude claude-sonnet-4-6*" \
+            --arg diff "$DIFF" \
+            --arg title "$PR_TITLE" \
+            --arg body "$PR_BODY" \
+            --arg trunc_note "$TRUNC_NOTE" \
+            '{
+              model: $model,
+              max_tokens: 2048,
+              system: $system,
+              messages: [
+                {
+                  role: "user",
+                  content: ("Review this pull request.\n\nPR Title: " + $title + "\n\nPR Description: " + $body + "\n\n" + $trunc_note + "\n\nDiff:\n```\n" + $diff + "\n```")
+                }
+              ]
+            }')
+
+          # Call the API
+          HTTP_CODE=$(curl -s -o /tmp/api_response.json -w "%{http_code}" \
+            https://api.anthropic.com/v1/messages \
+            -H "x-api-key: $ANTHROPIC_API_KEY" \
+            -H "anthropic-version: 2023-06-01" \
+            -H "content-type: application/json" \
+            -d "$PAYLOAD")
+
+          if [ "$HTTP_CODE" -ne 200 ]; then
+            echo "API returned HTTP $HTTP_CODE"
+            cat /tmp/api_response.json >&2 || true
+            echo "api_error=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          # Extract the review text
+          REVIEW=$(jq -r '.content[0].text' /tmp/api_response.json)
+          if [ -z "$REVIEW" ] || [ "$REVIEW" = "null" ]; then
+            echo "Failed to parse review from API response"
+            echo "api_error=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          # Write review to file for safe handling
+          printf '%s' "$REVIEW" > /tmp/review.txt
+          echo "api_error=false" >> "$GITHUB_OUTPUT"
+
+      - name: Post review comment
+        if: steps.check-key.outputs.skip != 'true' && steps.diff.outputs.skip != 'true' && steps.review.outputs.api_error != 'true'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          gh pr comment "${{ github.event.pull_request.number }}" \
+            --body "$(cat /tmp/review.txt)"
+
+      - name: Post skip comment (no code changes)
+        if: steps.check-key.outputs.skip != 'true' && steps.diff.outputs.skip == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh pr comment "${{ github.event.pull_request.number }}" \
+            --body "## AI Code Review
+
+          No code changes to review.
+
+          ---
+          *Reviewed by Claude claude-sonnet-4-6*"
+
+      - name: Post error comment
+        if: steps.check-key.outputs.skip != 'true' && steps.diff.outputs.skip != 'true' && steps.review.outputs.api_error == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh pr comment "${{ github.event.pull_request.number }}" \
+            --body "## AI Code Review
+
+          AI review unavailable: API error occurred. The review will be retried on the next push.
+
+          ---
+          *Reviewed by Claude claude-sonnet-4-6*"


### PR DESCRIPTION
## Summary

Adds a GitHub Actions workflow that automatically reviews pull requests using Claude (claude-sonnet-4-6). When a PR is opened or updated, the workflow fetches the diff, sends it to the Anthropic API for analysis, and posts a structured review comment on the PR.

## What it does

- Triggers on `pull_request` events: `opened`, `synchronize`, `reopened` (targeting `main`)
- Gets the PR diff using `gh pr diff`
- Truncates large diffs (>15k chars) with a note
- Calls Claude API with a system prompt specialized for this repo's stack (Go, K8s, Terraform, Helm, GitHub Actions)
- Posts structured review covering: Summary, Security, Correctness, Test Coverage, Style, and Suggestions
- Gracefully handles missing API key (skips), empty diffs (posts "no changes"), and API errors (posts "unavailable" + exits 0)

## Security

- All user-controlled inputs (PR title, body, diff) are passed via `env:` blocks, never interpolated in shell with `${{ }}`
- JSON payload is built with `jq --arg` to prevent injection via diff content
- `ANTHROPIC_API_KEY` is never echoed to logs
- Minimal permissions: `contents: read`, `pull-requests: write`

## Setup Required

Add `ANTHROPIC_API_KEY` to the repository secrets:

**Settings -> Secrets and variables -> Actions -> New repository secret**

- Name: `ANTHROPIC_API_KEY`
- Value: Your Anthropic API key

## Example Review Comment

```markdown
## AI Code Review

### Summary
This PR adds a new health check endpoint to the Go service...

### Security
No security concerns found.

### Correctness
The error handling in line 42 could mask connection timeouts...

### Test Coverage
Missing unit tests for the new endpoint handler.

### Style & Best Practices
Consider using constants for the HTTP status codes.

### Suggestions
1. Add a test for the timeout case
2. Use `http.StatusOK` instead of `200`

---
*Reviewed by Claude claude-sonnet-4-6*
```