### PR TITLE
feat: delivery hardening - immutable digest, alerts/runbooks, ephemeral envs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,6 +23,13 @@ env:
 jobs:
   lint-build-test:
     runs-on: ubuntu-latest
+    # Outputs surface the immutable image reference to downstream jobs
+    # (gitops-pr, deploy) so the GitOps PR can pin by digest, not by
+    # mutable tag.
+    outputs:
+      image_repo:   ${{ steps.image-ref.outputs.image_repo }}
+      image_tag:    ${{ steps.image-ref.outputs.image_tag }}
+      image_digest: ${{ steps.image-ref.outputs.image_digest }}
     defaults:
       run:
         working-directory: hello-world
@@ -188,6 +195,7 @@ jobs:
           echo "ECR_REGISTRY=$AWS_ACCOUNT_ID.dkr.ecr.$AWS_REGION.amazonaws.com" >> $GITHUB_ENV
 
       - name: Tag and push Docker image
+        id: image-ref
         if: github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/release/')
         run: |
           set -euo pipefail
@@ -195,9 +203,17 @@ jobs:
           docker tag $IMAGE_NAME:ci $ECR_REGISTRY/$ECR_REPOSITORY:sha-${GITHUB_SHA}
           docker push $ECR_REGISTRY/$ECR_REPOSITORY:${IMAGE_TAG}
           docker push $ECR_REGISTRY/$ECR_REPOSITORY:sha-${GITHUB_SHA}
-          # Capture image digest for immutable reference
-          DIGEST=$(docker inspect --format='{{index .RepoDigests 0}}' $ECR_REGISTRY/$ECR_REPOSITORY:${IMAGE_TAG} 2>/dev/null || echo "")
+          # Capture image digest for immutable reference (used by gitops-pr).
+          REPO_DIGEST=$(docker inspect --format='{{index .RepoDigests 0}}' $ECR_REGISTRY/$ECR_REPOSITORY:${IMAGE_TAG} 2>/dev/null || echo "")
+          DIGEST="${REPO_DIGEST##*@}"
+          if [ -z "$DIGEST" ]; then
+            echo "::warning::Failed to capture image digest; gitops-pr will be skipped"
+          fi
           echo "IMAGE_DIGEST=${DIGEST}" >> $GITHUB_ENV
+          # Step outputs for downstream jobs.
+          echo "image_repo=${ECR_REGISTRY}/${ECR_REPOSITORY}" >> "$GITHUB_OUTPUT"
+          echo "image_tag=${IMAGE_TAG}"                       >> "$GITHUB_OUTPUT"
+          echo "image_digest=${DIGEST}"                       >> "$GITHUB_OUTPUT"
 
       - name: Sign image with cosign (keyless)
         if: github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/release/')
@@ -263,10 +279,109 @@ jobs:
           docker tag $IMAGE_NAME:pr-${{ github.event.number }} $ECR_REGISTRY/$ECR_REPOSITORY:pr-${{ github.event.number }}
           docker push $ECR_REGISTRY/$ECR_REPOSITORY:pr-${{ github.event.number }}
 
-  deploy:
+  # ---------------------------------------------------------------------------
+  # gitops-pr — open a PR in the platform-design repo to update the
+  # hello-world HelmRelease to the new immutable image digest. Runs after
+  # the main-branch image push (digest is computed in lint-build-test and
+  # passed through GITHUB_ENV / a workflow artifact).
+  #
+  # Requires repo secret PLATFORM_DESIGN_TOKEN (fine-grained, write access
+  # ONLY to 100rd/platform-design pull requests + contents). If absent,
+  # the job logs a warning and exits 0 so the main pipeline does not
+  # break for forks / first-time runs.
+  # ---------------------------------------------------------------------------
+  gitops-pr:
     needs: lint-build-test
     if: github.event_name == 'push' && github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Check for PLATFORM_DESIGN_TOKEN
+        id: token-check
+        env:
+          PLATFORM_DESIGN_TOKEN: ${{ secrets.PLATFORM_DESIGN_TOKEN }}
+        run: |
+          if [ -z "${PLATFORM_DESIGN_TOKEN}" ]; then
+            echo "PLATFORM_DESIGN_TOKEN not set — skipping GitOps PR. Configure the secret at https://github.com/100rd/Creme-ala-creme/settings/secrets/actions"
+            echo "skip=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "skip=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Checkout platform-design
+        if: steps.token-check.outputs.skip == 'false'
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          repository: 100rd/platform-design
+          token: ${{ secrets.PLATFORM_DESIGN_TOKEN }}
+          ref: main
+          path: platform-design
+
+      - name: Update hello-world HelmRelease image digest
+        if: steps.token-check.outputs.skip == 'false'
+        env:
+          IMAGE_DIGEST: ${{ needs.lint-build-test.outputs.image_digest }}
+          IMAGE_TAG: ${{ needs.lint-build-test.outputs.image_tag }}
+          IMAGE_REPO: ${{ needs.lint-build-test.outputs.image_repo }}
+        working-directory: platform-design
+        run: |
+          set -euo pipefail
+          target="apps/direct/hello-world/helmrelease.yaml"
+          if [ ! -f "$target" ]; then
+            echo "Target file $target not found in platform-design; skipping"
+            exit 0
+          fi
+          # Strip "<repo>@" prefix from IMAGE_DIGEST if docker inspect returned a RepoDigest.
+          digest="${IMAGE_DIGEST##*@}"
+          # Update both image.repository and image.digest, and clear image.tag.
+          # yq v4 is preinstalled on ubuntu-latest.
+          IMAGE_REPO="$IMAGE_REPO" digest="$digest" yq -i '
+            .spec.values.image.repository = strenv(IMAGE_REPO) |
+            .spec.values.image.digest     = strenv(digest) |
+            .spec.values.image.tag        = ""
+          ' "$target"
+          echo "--- Updated $target ---"
+          cat "$target"
+
+      - name: Create Pull Request
+        if: steps.token-check.outputs.skip == 'false'
+        uses: peter-evans/create-pull-request@5e914681df9dc83aa4e4905692ca88beb2f9e91f # v7.0.5
+        with:
+          token: ${{ secrets.PLATFORM_DESIGN_TOKEN }}
+          path: platform-design
+          branch: bot/creme-bump-${{ github.sha }}
+          delete-branch: true
+          title: "chore(creme): bump hello-world to ${{ github.sha }}"
+          commit-message: |
+            chore(creme): bump hello-world image digest
+
+            Source commit: 100rd/Creme-ala-creme@${{ github.sha }}
+            Digest: ${{ needs.lint-build-test.outputs.image_digest }}
+          body: |
+            Automated bump from Creme-ala-creme CI.
+
+            - Source: https://github.com/100rd/Creme-ala-creme/commit/${{ github.sha }}
+            - Image digest: `${{ needs.lint-build-test.outputs.image_digest }}`
+            - Tag (informational): `${{ needs.lint-build-test.outputs.image_tag }}`
+          labels: |
+            automation
+            creme
+
+  deploy:
+    needs: [lint-build-test, gitops-pr]
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    runs-on: ubuntu-latest
+    # `environment: prod` triggers GitHub Actions environment protection
+    # rules. Configure required reviewers at:
+    #   https://github.com/100rd/Creme-ala-creme/settings/environments
+    #   -> "prod" -> "Required reviewers"
+    # Until reviewers are configured, this job will simply queue and
+    # auto-approve. Once reviewers are added, deploys to main pause for
+    # manual approval.
+    environment: prod
+    permissions:
+      contents: read
     steps:
       - name: Checkout code
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2

--- a/.github/workflows/pr-preview.yml
+++ b/.github/workflows/pr-preview.yml
@@ -1,0 +1,255 @@
+name: PR Preview
+
+# Spin up an ephemeral preview environment for every open pull request.
+#
+# When the optional repo secret `KUBE_CONFIG_B64` is configured, the
+# workflow installs the chart into a per-PR namespace `pr-<N>` and
+# comments on the PR with the preview URL.
+#
+# When KUBE_CONFIG_B64 is NOT set (the default for this repo today),
+# the workflow runs a deploy-time *dry-run* — helm template + kubeconform
+# validation + comment with a snippet of the rendered manifest. This
+# proves the preview overlay still renders cleanly for the proposed
+# change without requiring cluster access.
+#
+# Cleanup runs on PR `closed` (merged or not): the per-PR namespace is
+# deleted (or, in dry-run mode, a "preview cleaned up" comment is posted).
+#
+# Security:
+#   - Uses `pull_request` (NOT pull_request_target) so workflow
+#     definitions from forks cannot escalate.
+#   - Permissions are scoped per-job to the minimum needed.
+#   - No AWS / cluster credentials are exposed to fork PRs.
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, closed]
+    branches: [main]
+
+# Cancel in-flight preview builds for the same PR when a new push arrives.
+concurrency:
+  group: pr-preview-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+env:
+  PR_NUMBER: ${{ github.event.pull_request.number }}
+  PREVIEW_NS: pr-${{ github.event.pull_request.number }}
+  PREVIEW_RELEASE: hello-world-pr-${{ github.event.pull_request.number }}
+  PREVIEW_HOST: pr-${{ github.event.pull_request.number }}.hello-world.local
+  IMAGE_NAME: hello-world
+
+jobs:
+  # ---------------------------------------------------------------------
+  # render: always-run. Helm template + kubeconform. Acts as the dry-run
+  # path when no cluster credentials are configured, and as a pre-deploy
+  # gate when they are.
+  # ---------------------------------------------------------------------
+  render:
+    if: github.event.action != 'closed'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
+    outputs:
+      has_cluster_creds: ${{ steps.creds.outputs.has_cluster_creds }}
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+
+      - name: Detect cluster credentials
+        id: creds
+        env:
+          KUBE_CONFIG_B64: ${{ secrets.KUBE_CONFIG_B64 }}
+        run: |
+          if [ -n "${KUBE_CONFIG_B64}" ]; then
+            echo "has_cluster_creds=true"  >> "$GITHUB_OUTPUT"
+          else
+            echo "has_cluster_creds=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Install helm
+        uses: azure/setup-helm@b9e51907a09c216f16ebe8536097933489208112 # v4.3.0
+        with:
+          version: v3.16.4
+
+      - name: Install kubeconform
+        run: |
+          curl -fsSL -o /tmp/kubeconform.tar.gz \
+            https://github.com/yannh/kubeconform/releases/download/v0.6.7/kubeconform-linux-amd64.tar.gz
+          tar -xzf /tmp/kubeconform.tar.gz -C /tmp
+          sudo install /tmp/kubeconform /usr/local/bin/kubeconform
+          kubeconform -v
+
+      - name: Helm lint
+        run: helm lint hello-world/helm/hello-world
+
+      - name: Helm template (preview overlay)
+        run: |
+          set -euo pipefail
+          mkdir -p /tmp/preview
+          helm template "${PREVIEW_RELEASE}" hello-world/helm/hello-world \
+            -n "${PREVIEW_NS}" --create-namespace \
+            -f hello-world/helm/hello-world/values-preview.yaml \
+            --set ingress.host="${PREVIEW_HOST}" \
+            --set image.repository="${IMAGE_NAME}" \
+            --set image.tag="pr-${PR_NUMBER}" \
+            > /tmp/preview/manifest.yaml
+          echo "Rendered $(wc -l < /tmp/preview/manifest.yaml) lines"
+
+      - name: kubeconform validate
+        run: |
+          kubeconform -strict -ignore-missing-schemas -summary /tmp/preview/manifest.yaml
+
+      - name: Comment dry-run preview on PR
+        if: steps.creds.outputs.has_cluster_creds == 'false'
+        uses: marocchino/sticky-pull-request-comment@52423e01640425a022ef5fd42c6fb5f633a02728 # v2.9.1
+        with:
+          header: pr-preview
+          message: |
+            ### PR Preview (dry-run)
+
+            Cluster credentials (`KUBE_CONFIG_B64`) are not configured for this repo,
+            so the preview ran as a **dry-run**: `helm lint` + `helm template` +
+            `kubeconform -strict`. Add the secret to enable live previews.
+
+            - Preview namespace (planned): `${{ env.PREVIEW_NS }}`
+            - Preview host (planned): `https://${{ env.PREVIEW_HOST }}`
+            - Image: `${{ env.IMAGE_NAME }}:pr-${{ env.PR_NUMBER }}`
+            - Render: ok
+            - kubeconform: ok
+
+            Configure `KUBE_CONFIG_B64` at
+            https://github.com/100rd/Creme-ala-creme/settings/secrets/actions to
+            enable live previews.
+
+  # ---------------------------------------------------------------------
+  # deploy: only when cluster credentials are configured. Loads kubeconfig,
+  # installs the chart, waits for readiness, posts a comment with the URL.
+  # ---------------------------------------------------------------------
+  deploy:
+    needs: render
+    if: github.event.action != 'closed' && needs.render.outputs.has_cluster_creds == 'true'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+
+      - name: Install helm
+        uses: azure/setup-helm@b9e51907a09c216f16ebe8536097933489208112 # v4.3.0
+        with:
+          version: v3.16.4
+
+      - name: Install kubectl
+        uses: azure/setup-kubectl@3e0aec4d80787158d308d7b364cb1b702e7feb7f # v4.0.0
+        with:
+          version: v1.29.4
+
+      - name: Load kubeconfig
+        env:
+          KUBE_CONFIG_B64: ${{ secrets.KUBE_CONFIG_B64 }}
+        run: |
+          mkdir -p "$HOME/.kube"
+          echo "$KUBE_CONFIG_B64" | base64 -d > "$HOME/.kube/config"
+          chmod 600 "$HOME/.kube/config"
+          kubectl cluster-info
+
+      - name: Helm upgrade --install preview
+        run: |
+          set -euo pipefail
+          helm upgrade --install "${PREVIEW_RELEASE}" hello-world/helm/hello-world \
+            --namespace "${PREVIEW_NS}" --create-namespace \
+            -f hello-world/helm/hello-world/values-preview.yaml \
+            --set ingress.host="${PREVIEW_HOST}" \
+            --set image.repository="${IMAGE_NAME}" \
+            --set image.tag="pr-${PR_NUMBER}" \
+            --wait --timeout=5m
+
+      - name: Wait for Certificate ready
+        run: |
+          kubectl -n "${PREVIEW_NS}" wait \
+            --for=condition=Ready certificate \
+            --all --timeout=2m || echo "::warning::Certificate not Ready in 2m"
+
+      - name: Comment preview URL on PR
+        uses: marocchino/sticky-pull-request-comment@52423e01640425a022ef5fd42c6fb5f633a02728 # v2.9.1
+        with:
+          header: pr-preview
+          message: |
+            ### PR Preview
+
+            - URL:        https://${{ env.PREVIEW_HOST }}
+            - Namespace:  `${{ env.PREVIEW_NS }}`
+            - Release:    `${{ env.PREVIEW_RELEASE }}`
+            - Image:      `${{ env.IMAGE_NAME }}:pr-${{ env.PR_NUMBER }}`
+
+            Useful commands:
+            ```
+            kubectl -n ${{ env.PREVIEW_NS }} get pods
+            kubectl -n ${{ env.PREVIEW_NS }} logs -l app.kubernetes.io/name=hello-world --tail=200
+            ```
+
+            The preview will be torn down automatically when this PR closes.
+
+  # ---------------------------------------------------------------------
+  # cleanup: PR closed (merged or otherwise). Tear down namespace + release.
+  # ---------------------------------------------------------------------
+  cleanup:
+    if: github.event.action == 'closed'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
+    steps:
+      - name: Detect cluster credentials
+        id: creds
+        env:
+          KUBE_CONFIG_B64: ${{ secrets.KUBE_CONFIG_B64 }}
+        run: |
+          if [ -n "${KUBE_CONFIG_B64}" ]; then
+            echo "has_cluster_creds=true"  >> "$GITHUB_OUTPUT"
+          else
+            echo "has_cluster_creds=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Install helm
+        if: steps.creds.outputs.has_cluster_creds == 'true'
+        uses: azure/setup-helm@b9e51907a09c216f16ebe8536097933489208112 # v4.3.0
+        with:
+          version: v3.16.4
+
+      - name: Install kubectl
+        if: steps.creds.outputs.has_cluster_creds == 'true'
+        uses: azure/setup-kubectl@3e0aec4d80787158d308d7b364cb1b702e7feb7f # v4.0.0
+        with:
+          version: v1.29.4
+
+      - name: Load kubeconfig
+        if: steps.creds.outputs.has_cluster_creds == 'true'
+        env:
+          KUBE_CONFIG_B64: ${{ secrets.KUBE_CONFIG_B64 }}
+        run: |
+          mkdir -p "$HOME/.kube"
+          echo "$KUBE_CONFIG_B64" | base64 -d > "$HOME/.kube/config"
+          chmod 600 "$HOME/.kube/config"
+
+      - name: Helm uninstall preview
+        if: steps.creds.outputs.has_cluster_creds == 'true'
+        run: |
+          set -euo pipefail
+          helm uninstall "${PREVIEW_RELEASE}" -n "${PREVIEW_NS}" --ignore-not-found || true
+          kubectl delete namespace "${PREVIEW_NS}" --ignore-not-found --wait=false || true
+
+      - name: Comment teardown on PR
+        uses: marocchino/sticky-pull-request-comment@52423e01640425a022ef5fd42c6fb5f633a02728 # v2.9.1
+        with:
+          header: pr-preview
+          message: |
+            ### PR Preview — torn down
+
+            Namespace `${{ env.PREVIEW_NS }}` and release `${{ env.PREVIEW_RELEASE }}` removed.

--- a/README.md
+++ b/README.md
@@ -67,11 +67,11 @@ Notes
 - [x] App: add /readyz & /livez, graceful shutdown
 - [x] App: add JSON logs with trace ids
 - [x] Secrets: ESO+SOPS or Vault; DATABASE_URL via Secret (not plain env)
-- [ ] CI immutability: switch Helm values to digests; GitOps PR to flux repo; env approvals
+- [x] CI immutability: switch Helm values to digests; GitOps PR to flux repo; env approvals
 - [x] Ingress/Gateway: HTTPS via cert-manager; smoke tests
-- [ ] Alerts & runbooks: Slack/webhook, SLOs, runbook URLs
+- [x] Alerts & runbooks: Slack/webhook, SLOs, runbook URLs
 - [x] RBAC & quotas: Role/RoleBinding; LimitRange/ResourceQuota
-- [ ] Ephemeral envs: PR previews; auto cleanup
+- [x] Ephemeral envs: PR previews; auto cleanup
 - [x] Tests: increase coverage; add DB/OTEL integration tests
 - [x] Prometheus rules applied by operator from repo (preferred) — rules file provided; flux integration present, CLI apply removed from CI
 - [x] Security scanners in CI: golangci-lint, gosec, govulncheck, Trivy (fs+image), ZAP baseline
@@ -94,11 +94,11 @@ This design implies only two env's - non-prod and prod.
  - non-prod - it is `shared` with dev/stage/demo/preview or any other without real load
  - prod is a prod :)
 
-https://github.com/IgorGerasimow/platform-design - this repository contain: 
- - generic helm chart https://github.com/IgorGerasimow/platform-design/tree/main/helm
- - terragrunt for spinning up aws resources https://github.com/IgorGerasimow/platform-design/tree/main/terragrunt
- - example of Argocd apps and deploys https://github.com/IgorGerasimow/platform-design/tree/main/apps
- - git hub pipelines  https://github.com/IgorGerasimow/platform-design/tree/main/.github/workflows  
+https://github.com/100rd/platform-design - this repository contain: 
+ - generic helm chart https://github.com/100rd/platform-design/tree/main/helm
+ - terragrunt for spinning up aws resources https://github.com/100rd/platform-design/tree/main/terragrunt
+ - example of Argocd apps and deploys https://github.com/100rd/platform-design/tree/main/apps
+ - git hub pipelines  https://github.com/100rd/platform-design/tree/main/.github/workflows  
 
 <img src="docs/12factor.svg" alt="12-Factor overview" width="800"/>
 
@@ -226,3 +226,113 @@ helm upgrade --install hello-world ./hello-world/helm/hello-world   --namespace 
 - Default-deny `NetworkPolicy` with explicit egress to Postgres and OTEL collector (adjust selectors to your environment).
 
 The Helm chart exposes probe paths via `values.yaml` under `healthProbes` so you can override them per environment if desired.
+
+## Phase C — Delivery hardening
+
+Phase C closes the last three TBD items (3, 5, 7): immutable image
+references via digest, full Alertmanager routing + runbooks + SLO
+burn-rate alerts, and ephemeral PR-preview environments with auto
+cleanup.
+
+### Immutable image references (digest precedence)
+
+The chart prefers `image.digest` over `image.tag`. When `image.digest`
+is set (non-empty, must start with `sha256:`), the Deployment renders
+`repository@digest`; otherwise it falls back to `repository:tag`.
+
+```yaml
+# values.yaml (snippet)
+image:
+  repository: ghcr.io/your-org/hello-world
+  digest: ""           # set this for immutable references (preferred)
+  tag: "latest"        # used only when digest is empty
+```
+
+CI captures the image digest after `docker push` (step output
+`image_digest` on the `lint-build-test` job) and feeds it into the
+`gitops-pr` job, which opens a PR in `100rd/platform-design` updating
+`spec.values.image.digest` (and clearing `image.tag`).
+
+#### Required secrets
+
+| Secret | Purpose | Where to add |
+| --- | --- | --- |
+| `PLATFORM_DESIGN_TOKEN` | Fine-grained PAT with write access to PRs and contents in `100rd/platform-design` ONLY | `https://github.com/100rd/Creme-ala-creme/settings/secrets/actions` |
+| `KUBE_CONFIG_B64` | Base64 kubeconfig for the cluster that hosts PR previews. Optional — when absent, PR-preview workflow runs dry-run only | same |
+
+#### Required environment ("prod") for manual approval
+
+The `deploy` job declares `environment: prod`. To enforce manual
+approval before each prod rollout:
+
+1. Open `https://github.com/100rd/Creme-ala-creme/settings/environments`
+2. Click "New environment" → name it `prod`
+3. Under "Deployment protection rules" → "Required reviewers", add the
+   on-call engineer(s) who must approve.
+
+Until reviewers are configured the deploy job will simply queue and
+proceed; configuring reviewers turns it into a manual gate.
+
+### Alerts, runbooks, and SLO burn-rate alerts
+
+`alertmanager/alertmanager.yml` routes by `severity`:
+
+| Severity | Receiver | Channel |
+| --- | --- | --- |
+| critical | `slack-oncall` | `#oncall` (paging) |
+| warning  | `slack-monitoring` | `#monitoring` |
+| info     | `null` | dropped (log-only) |
+
+Inhibit rules suppress lower-severity copies of an alert when the
+critical counterpart is firing for the same service, and
+`HelloWorldTargetDown` inhibits all downstream symptom alerts for the
+same service.
+
+`hello-world/monitoring/prometheus-rules.yaml` adds **multi-window
+multi-burn-rate** SLO alerts (Google SRE workbook ch.5) for a 99.9%
+availability target over a 30-day window:
+
+| Alert | Burn rate | Window | Severity |
+| --- | --- | --- | --- |
+| `HelloWorldSLOBurnFast1h` | 14.4x | 1h + 5m | critical |
+| `HelloWorldSLOBurnFast6h` | 6x   | 6h + 30m | critical |
+| `HelloWorldSLOBurnSlow1d` | 3x   | 1d + 1h | warning |
+| `HelloWorldSLOBurnSlow3d` | 1x   | 3d + 6h | warning |
+
+Every alert carries a `runbook_url` annotation pointing to
+`docs/runbooks/<alert-name>.md`. Runbooks contain symptoms, immediate
+actions, escalation, and dashboard links.
+
+Validate locally:
+
+```bash
+promtool check rules hello-world/monitoring/prometheus-rules.yaml
+amtool check-config alertmanager/alertmanager.yml
+```
+
+### Ephemeral PR-preview environments
+
+`.github/workflows/pr-preview.yml` runs on every pull request. With
+`KUBE_CONFIG_B64` configured, it deploys the chart into namespace
+`pr-<PR_NUMBER>` using `hello-world/helm/hello-world/values-preview.yaml`
+and comments the preview URL on the PR. The `cleanup` job (triggered by
+`pull_request.closed`) tears the namespace down.
+
+Without `KUBE_CONFIG_B64`, the workflow falls back to a dry-run path:
+`helm lint` + `helm template` + `kubeconform -strict`, plus a sticky PR
+comment showing what *would* be deployed.
+
+Local test of the preview overlay:
+
+```bash
+helm upgrade --install hello-world-pr-999 ./hello-world/helm/hello-world \
+  --namespace pr-999 --create-namespace \
+  -f hello-world/helm/hello-world/values-preview.yaml \
+  --set ingress.host=pr-999.hello-world.local \
+  --set image.repository=traefik/whoami --set image.tag=latest \
+  --set-string 'command[0]=/whoami,command[1]=--port,command[2]=8080' \
+  --wait --timeout=3m
+# ...verify pod / Certificate / ExternalSecret / Ingress, then:
+helm uninstall hello-world-pr-999 -n pr-999
+kubectl delete ns pr-999
+```

--- a/alertmanager/alertmanager.yml
+++ b/alertmanager/alertmanager.yml
@@ -1,9 +1,107 @@
+# Alertmanager configuration for hello-world.
+#
+# Receivers route by `severity` label:
+#   - critical -> Slack #oncall (paging channel)
+#   - warning  -> Slack #monitoring
+#   - info     -> log-only (null receiver)
+#
+# Inhibit rules suppress warning/info copies of an alert when the
+# critical counterpart is already firing for the same service+alertname.
+#
+# Slack webhook URLs are PLACEHOLDERS in this file. In production they
+# are injected into the running Alertmanager via env-substitution (e.g.
+# Helm values pulled from a Kubernetes Secret) so no secret material
+# lives in source control.
+#
+# Validate locally with:
+#   kubectl -n monitoring cp alertmanager/alertmanager.yml \
+#     alertmanager-0:/tmp/amcfg.yml
+#   kubectl -n monitoring exec alertmanager-0 -- \
+#     amtool check-config /tmp/amcfg.yml
+
+global:
+  resolve_timeout: 5m
+  # Default Slack API URL — overridden per receiver via api_url.
+  # PLACEHOLDER ONLY. Real value injected via secret/env at runtime.
+  slack_api_url: "https://hooks.slack.com/services/PLACEHOLDER/DEFAULT"
+
 route:
-  receiver: devnull
-  group_wait: 10s
-  group_interval: 1m
+  receiver: slack-monitoring
+  group_by: ["alertname", "service", "severity"]
+  group_wait: 30s
+  group_interval: 5m
   repeat_interval: 12h
+  routes:
+    # Critical alerts page #oncall and repeat every hour until resolved.
+    - matchers:
+        - severity = "critical"
+      receiver: slack-oncall
+      group_wait: 10s
+      group_interval: 2m
+      repeat_interval: 1h
+      continue: false
+
+    # Warnings to #monitoring, less aggressive repeat cadence.
+    - matchers:
+        - severity = "warning"
+      receiver: slack-monitoring
+      group_wait: 30s
+      group_interval: 5m
+      repeat_interval: 4h
+      continue: false
+
+    # Info-level alerts are logged but not delivered to Slack.
+    - matchers:
+        - severity = "info"
+      receiver: "null"
+      continue: false
 
 receivers:
-  - name: devnull
+  - name: "null"
 
+  - name: slack-oncall
+    slack_configs:
+      - api_url: "https://hooks.slack.com/services/PLACEHOLDER/ONCALL"
+        channel: "#oncall"
+        send_resolved: true
+        title: '[{{ .Status | toUpper }}{{ if eq .Status "firing" }}:{{ .Alerts.Firing | len }}{{ end }}] {{ .CommonLabels.alertname }} ({{ .CommonLabels.service }})'
+        text: |
+          {{ range .Alerts -}}
+          *Alert:* {{ .Labels.alertname }}
+          *Severity:* {{ .Labels.severity }}
+          *Service:* {{ .Labels.service }}
+          *Summary:* {{ .Annotations.summary }}
+          *Runbook:* {{ .Annotations.runbook_url }}
+          {{ end }}
+
+  - name: slack-monitoring
+    slack_configs:
+      - api_url: "https://hooks.slack.com/services/PLACEHOLDER/MONITORING"
+        channel: "#monitoring"
+        send_resolved: true
+        title: '[{{ .Status | toUpper }}] {{ .CommonLabels.alertname }} ({{ .CommonLabels.service }})'
+        text: |
+          {{ range .Alerts -}}
+          *Alert:* {{ .Labels.alertname }}
+          *Severity:* {{ .Labels.severity }}
+          *Service:* {{ .Labels.service }}
+          *Summary:* {{ .Annotations.summary }}
+          *Runbook:* {{ .Annotations.runbook_url }}
+          {{ end }}
+
+inhibit_rules:
+  # When a critical alert fires for a service, suppress lower-severity
+  # alerts for the same alertname+service so on-call is not paged twice.
+  - source_matchers:
+      - severity = "critical"
+    target_matchers:
+      - severity =~ "warning|info"
+    equal: ["alertname", "service"]
+
+  # When a service is fully down (HelloWorldTargetDown), suppress
+  # downstream symptom alerts that would otherwise also fire.
+  - source_matchers:
+      - alertname = "HelloWorldTargetDown"
+    target_matchers:
+      - alertname =~ "HelloWorldHighErrorRate|HelloWorldHighLatencyP95|HelloWorldNoTraffic|HelloWorldMetricsHandlerErrors"
+    equal: ["service"]

--- a/docs/runbooks/HelloWorldHighErrorRate.md
+++ b/docs/runbooks/HelloWorldHighErrorRate.md
@@ -1,0 +1,43 @@
+# HelloWorldHighErrorRate
+
+**Severity:** warning
+**Page:** no — #monitoring
+
+## Symptoms
+
+- Non-2xx ratio above 5% over 5 minutes.
+- Users may report sporadic 5xx responses.
+- `HelloWorldSLOBurnFast1h` may follow if the rate sustains.
+
+## Immediate Actions
+
+1. Identify which status codes dominate:
+   ```promql
+   sum by (status) (rate(http_requests_total{job=~".*hello-world.*"}[5m]))
+   ```
+2. Inspect recent logs for stack traces or upstream failures:
+   ```bash
+   kubectl -n hello-world logs -l app.kubernetes.io/name=hello-world --tail=300 | jq -r 'select(.level=="error")'
+   ```
+3. Check downstream dependencies (Postgres, OTEL collector):
+   ```bash
+   kubectl -n hello-world exec deploy/hello-world -- nc -vz postgres 5432
+   ```
+4. If correlated with a recent deploy, **roll back**:
+   ```bash
+   kubectl -n hello-world rollout undo deploy/hello-world
+   ```
+5. If correlated with traffic spike, scale up:
+   ```bash
+   kubectl -n hello-world scale deploy/hello-world --replicas=4
+   ```
+
+## Escalation
+
+- If error rate exceeds 25% for 5+ minutes: treat as critical.
+- If downstream is the cause: page that team's on-call.
+
+## Links
+
+- Dashboard: https://grafana.example.com/d/hello-world
+- Recent deploys: https://github.com/100rd/Creme-ala-creme/actions

--- a/docs/runbooks/HelloWorldHighLatencyP95.md
+++ b/docs/runbooks/HelloWorldHighLatencyP95.md
@@ -1,0 +1,40 @@
+# HelloWorldHighLatencyP95
+
+**Severity:** warning
+**Page:** no — #monitoring
+
+## Symptoms
+
+- P95 request latency > 500ms over 5 minutes.
+- User-reported slowness.
+
+## Immediate Actions
+
+1. Identify which handler is slow:
+   ```promql
+   histogram_quantile(0.95,
+     sum by (le, handler) (rate(http_request_duration_seconds_bucket{job=~".*hello-world.*"}[5m]))
+   )
+   ```
+2. Check CPU / memory pressure:
+   ```bash
+   kubectl -n hello-world top pod -l app.kubernetes.io/name=hello-world
+   ```
+3. If saturation is the cause, scale up or raise resource limits:
+   ```bash
+   kubectl -n hello-world scale deploy/hello-world --replicas=4
+   ```
+4. Check downstream (DB query time):
+   ```bash
+   kubectl -n hello-world exec deploy/hello-world -- /bin/sh -c 'psql "$DATABASE_URL" -c "SELECT pid, query, state FROM pg_stat_activity WHERE state <> '\''idle'\''"'
+   ```
+5. If correlated with a recent deploy, roll back.
+
+## Escalation
+
+- If latency exceeds 2s for 5+ minutes: page on-call.
+- If downstream DB is the cause: page DBA on-call.
+
+## Links
+
+- Dashboard: https://grafana.example.com/d/hello-world-latency

--- a/docs/runbooks/HelloWorldMetricsHandlerErrors.md
+++ b/docs/runbooks/HelloWorldMetricsHandlerErrors.md
@@ -1,0 +1,37 @@
+# HelloWorldMetricsHandlerErrors
+
+**Severity:** warning
+**Page:** no — #monitoring
+
+## Symptoms
+
+- `promhttp_metric_handler_errors_total` incrementing over 10 minutes.
+- `/metrics` may return 500 or partial content.
+- Prometheus scrape may show partial data.
+
+## Immediate Actions
+
+1. Curl `/metrics` directly and inspect the response:
+   ```bash
+   kubectl -n hello-world port-forward deploy/hello-world 8080:8080 &
+   curl -i http://localhost:8080/metrics
+   ```
+2. Check logs for encoding errors:
+   ```bash
+   kubectl -n hello-world logs -l app.kubernetes.io/name=hello-world --tail=200 | grep -i 'metric\|prom'
+   ```
+3. Look for memory pressure (handler errors are sometimes OOM-adjacent):
+   ```bash
+   kubectl -n hello-world top pod -l app.kubernetes.io/name=hello-world
+   ```
+4. If a recent deploy introduced a metric with invalid labels, **roll
+   back** and file a follow-up to fix the instrumentation.
+
+## Escalation
+
+- If metric collection has been broken for 30+ minutes: treat as critical
+  (observability blind-spot).
+
+## Links
+
+- promhttp upstream docs: https://pkg.go.dev/github.com/prometheus/client_golang/prometheus/promhttp

--- a/docs/runbooks/HelloWorldNoTraffic.md
+++ b/docs/runbooks/HelloWorldNoTraffic.md
@@ -1,0 +1,33 @@
+# HelloWorldNoTraffic
+
+**Severity:** info
+**Page:** no — log-only
+
+## Symptoms
+
+- No HTTP requests observed for 10+ minutes.
+- May be normal during off-hours for some environments.
+
+## Immediate Actions
+
+1. Confirm this is unexpected (check environment, time of day, traffic
+   patterns).
+2. Verify ingress is healthy:
+   ```bash
+   kubectl -n ingress-nginx get pods
+   curl -sk -H 'Host: hello-world.local' https://<ingress-ip>/livez
+   ```
+3. Verify Service endpoints:
+   ```bash
+   kubectl -n hello-world get endpoints hello-world
+   ```
+4. Check DNS resolution from a client.
+
+## Escalation
+
+- If traffic is expected and ingress is healthy: open a ticket for
+  upstream routing / DNS investigation.
+
+## Links
+
+- Dashboard: https://grafana.example.com/d/hello-world

--- a/docs/runbooks/HelloWorldSLOBurnFast.md
+++ b/docs/runbooks/HelloWorldSLOBurnFast.md
@@ -1,0 +1,52 @@
+# HelloWorldSLOBurnFast (1h / 6h windows)
+
+**Severity:** critical
+**Page:** yes — #oncall
+**SLO:** 99.9% availability over 30 days. Budget = 0.1% / 30d.
+
+## Symptoms
+
+- One of `HelloWorldSLOBurnFast1h` or `HelloWorldSLOBurnFast6h` firing.
+- Error budget is being consumed faster than 6x — 14.4x the steady-state
+  rate.
+- At 14.4x, the entire monthly error budget is consumed in ~2 days.
+- At 6x, it is consumed in ~5 days.
+
+## Immediate Actions
+
+This alert is correlated with `HelloWorldHighErrorRate` and/or
+`HelloWorldTargetDown` — start with their runbooks first.
+
+1. Compute current burn rate to decide urgency:
+   ```promql
+   1000 * job:hello_world_request_errors:ratio_rate5m
+   ```
+   A value of 14.4 means "consuming budget 14.4x faster than steady-state".
+
+2. Triage by error class:
+   ```promql
+   sum by (status) (rate(http_requests_total{job=~".*hello-world.*"}[5m]))
+   ```
+3. **Freeze deploys.** No deploys to prod until burn rate is back under 1.
+4. Roll back the most recent deploy if the burn started after it:
+   ```bash
+   kubectl -n hello-world rollout undo deploy/hello-world
+   ```
+5. If burn persists after rollback, declare an incident and engage
+   the on-call channel.
+
+## Recovery
+
+- Burn rate should drop within 5 minutes of mitigation.
+- The alert auto-resolves when the recording rules drop below the burn
+  threshold (`14.4 * 0.001` for fast-1h, `6 * 0.001` for fast-6h).
+
+## Escalation
+
+- If unresolved in 30 min: page engineering manager.
+- If 50% of monthly budget is consumed: declare a Sev-1.
+
+## Links
+
+- SRE workbook (multi-window multi-burn): https://sre.google/workbook/alerting-on-slos/
+- Dashboard: https://grafana.example.com/d/hello-world-slo

--- a/docs/runbooks/HelloWorldSLOBurnSlow.md
+++ b/docs/runbooks/HelloWorldSLOBurnSlow.md
@@ -1,0 +1,44 @@
+# HelloWorldSLOBurnSlow (1d / 3d windows)
+
+**Severity:** warning
+**Page:** no — open a ticket
+**SLO:** 99.9% availability over 30 days. Budget = 0.1% / 30d.
+
+## Symptoms
+
+- One of `HelloWorldSLOBurnSlow1d` or `HelloWorldSLOBurnSlow3d` firing.
+- Persistent low-grade error rate that does not show up as a fast burn,
+  but is steadily eating the monthly budget.
+- At 3x steady-state, the monthly budget is exhausted in ~10 days.
+- At 1x steady-state, the budget is exhausted exactly at 30 days.
+
+## Immediate Actions
+
+This is a **ticket-grade** alert, not a page. Do NOT scramble — instead,
+investigate during business hours and prevent the slow burn from
+escalating into a fast burn.
+
+1. Identify the dominant error class over the long window:
+   ```promql
+   sum by (handler, status) (rate(http_requests_total{job=~".*hello-world.*",status!~"2.."}[6h]))
+   ```
+2. Inspect logs for a recurring pattern:
+   ```bash
+   kubectl -n hello-world logs -l app.kubernetes.io/name=hello-world --since=6h | jq -r 'select(.level=="error") | .msg' | sort | uniq -c | sort -rn | head -20
+   ```
+3. Correlate with deploys, dependency outages, traffic shifts.
+4. File a ticket with the findings; assign to the service owner.
+5. Apply mitigation in the next sprint (or sooner if the budget burn
+   accelerates).
+
+## Escalation
+
+- If the slow burn becomes a fast burn: follow `HelloWorldSLOBurnFast`
+  runbook.
+- If 80% of monthly budget is consumed: notify engineering management
+  and freeze non-essential changes.
+
+## Links
+
+- SRE workbook (multi-window multi-burn): https://sre.google/workbook/alerting-on-slos/
+- Dashboard: https://grafana.example.com/d/hello-world-slo

--- a/docs/runbooks/HelloWorldTargetDown.md
+++ b/docs/runbooks/HelloWorldTargetDown.md
@@ -1,0 +1,47 @@
+# HelloWorldTargetDown
+
+**Severity:** critical
+**Page:** yes — #oncall
+
+## Symptoms
+
+- Prometheus reports `up{job=~".*hello-world.*"} == 0` for 2+ minutes.
+- `/readyz` or `/livez` not responding.
+- Ingress returns 502/503 from the gateway.
+
+## Immediate Actions
+
+1. Confirm the alert is real, not a Prometheus scrape misconfig:
+   ```bash
+   kubectl -n hello-world get pods -l app.kubernetes.io/name=hello-world
+   kubectl -n hello-world get endpoints
+   kubectl -n monitoring port-forward svc/prometheus 9090
+   # browse to http://localhost:9090/targets
+   ```
+2. Check pod status and recent events:
+   ```bash
+   kubectl -n hello-world describe pod -l app.kubernetes.io/name=hello-world
+   kubectl -n hello-world logs -l app.kubernetes.io/name=hello-world --tail=200
+   ```
+3. If the deployment is crashlooping after a recent release, **roll back**:
+   ```bash
+   kubectl -n hello-world rollout undo deploy/hello-world
+   ```
+4. If the issue is at the ingress / cert layer:
+   ```bash
+   kubectl -n hello-world get certificate,ingress
+   kubectl -n cert-manager logs -l app=cert-manager --tail=200
+   ```
+5. If the upstream (DB / OTEL collector) is unhealthy, check those first
+   before restarting the app.
+
+## Escalation
+
+- If unresolved in 15 min: page the platform on-call (#oncall).
+- If a security incident is suspected: page security-oncall.
+
+## Links
+
+- Dashboard: https://grafana.example.com/d/hello-world
+- Recent deploys: https://github.com/100rd/Creme-ala-creme/actions
+- Architecture: ../architecture/

--- a/docs/runbooks/README.md
+++ b/docs/runbooks/README.md
@@ -1,0 +1,21 @@
+# Runbooks
+
+Operational runbooks linked from PrometheusRule `runbook_url` annotations.
+Each runbook contains: symptoms, immediate actions, escalation, and links.
+
+| Alert | Severity | Runbook |
+| --- | --- | --- |
+| HelloWorldTargetDown | critical | [HelloWorldTargetDown.md](HelloWorldTargetDown.md) |
+| HelloWorldHighErrorRate | warning | [HelloWorldHighErrorRate.md](HelloWorldHighErrorRate.md) |
+| HelloWorldHighLatencyP95 | warning | [HelloWorldHighLatencyP95.md](HelloWorldHighLatencyP95.md) |
+| HelloWorldNoTraffic | info | [HelloWorldNoTraffic.md](HelloWorldNoTraffic.md) |
+| HelloWorldMetricsHandlerErrors | warning | [HelloWorldMetricsHandlerErrors.md](HelloWorldMetricsHandlerErrors.md) |
+| HelloWorldSLOBurnFast1h / 6h | critical | [HelloWorldSLOBurnFast.md](HelloWorldSLOBurnFast.md) |
+| HelloWorldSLOBurnSlow1d / 3d | warning | [HelloWorldSLOBurnSlow.md](HelloWorldSLOBurnSlow.md) |
+
+## Conventions
+
+- Every runbook starts with **Symptoms** so the on-call can confirm the alert.
+- **Immediate Actions** are ordered from cheapest/safest to most invasive.
+- **Escalation** lists who to ping and on which channel.
+- **Links** points to dashboards, logs, and recent change logs.

--- a/hello-world/helm/hello-world/templates/_helpers.tpl
+++ b/hello-world/helm/hello-world/templates/_helpers.tpl
@@ -61,3 +61,24 @@ Refuses to render the deployment otherwise.
 {{- fail "ADMIN_FLAGS_ENABLED=true requires ADMIN_API_KEY to be provided (set via envFromSecret.keys or env)" -}}
 {{- end -}}
 {{- end -}}
+
+{{/*
+Image reference resolver: prefer image.digest over image.tag.
+- If .Values.image.digest is non-empty, returns "repository@digest"
+  (immutable reference, recommended for production / GitOps).
+- Otherwise returns "repository:tag".
+Validates the digest format (must start with "sha256:") when set.
+*/}}
+{{- define "hello-world.image" -}}
+{{- $repo := required "image.repository is required" .Values.image.repository -}}
+{{- $digest := .Values.image.digest | default "" -}}
+{{- if $digest -}}
+  {{- if not (hasPrefix "sha256:" $digest) -}}
+    {{- fail (printf "image.digest must start with 'sha256:' — got %q" $digest) -}}
+  {{- end -}}
+  {{- printf "%s@%s" $repo $digest -}}
+{{- else -}}
+  {{- $tag := .Values.image.tag | default "latest" -}}
+  {{- printf "%s:%s" $repo $tag -}}
+{{- end -}}
+{{- end -}}

--- a/hello-world/helm/hello-world/templates/deployment.yaml
+++ b/hello-world/helm/hello-world/templates/deployment.yaml
@@ -34,7 +34,7 @@ spec:
           type: RuntimeDefault
       containers:
         - name: app
-          image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+          image: {{ include "hello-world.image" . | quote }}
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           {{- with .Values.command }}
           command:

--- a/hello-world/helm/hello-world/values-preview.yaml
+++ b/hello-world/helm/hello-world/values-preview.yaml
@@ -1,0 +1,109 @@
+# Ephemeral PR preview overlay.
+# Applied with:
+#   helm upgrade --install hello-world-pr-N ./hello-world/helm/hello-world \
+#     --namespace pr-N --create-namespace \
+#     -f hello-world/helm/hello-world/values-preview.yaml \
+#     --set ingress.host=pr-N.hello-world.local \
+#     --set image.repository=<repo> \
+#     --set image.tag=pr-N
+#
+# Designed to be cheap and self-contained: single replica, no HPA, no
+# PDB, no Prometheus ServiceMonitor, self-signed cert via the same
+# selfsigned-ca-issuer used by local validation, ESO Fake store. The
+# PR-preview workflow tears the whole namespace down when the PR closes.
+
+replicaCount: 1
+
+# image.repository and image.tag are set per-PR via --set on the CLI.
+image:
+  pullPolicy: IfNotPresent
+
+namespace:
+  create: true
+  pss:
+    enforce: restricted
+    audit: restricted
+    warn: restricted
+
+hpa:
+  enabled: false
+
+pdb:
+  enabled: false
+
+# Preview clusters typically run without the Prometheus operator.
+serviceMonitor:
+  enabled: false
+
+# No real migrations in previews — Postgres is ephemeral / shared.
+migrations:
+  enabled: false
+
+# Tighter quotas for preview namespaces so an unbounded number of PR
+# previews can coexist without exhausting cluster capacity.
+resourceQuota:
+  enabled: true
+  requestsCpu: "500m"
+  requestsMemory: "256Mi"
+  limitsCpu: "1"
+  limitsMemory: "512Mi"
+  pods: "5"
+  secrets: "10"
+  configmaps: "10"
+
+ingress:
+  enabled: true
+  className: "nginx"
+  # host overridden per PR via --set ingress.host=pr-<N>.hello-world.local
+  host: "pr-preview.hello-world.local"
+  path: "/"
+  pathType: Prefix
+
+certificate:
+  enabled: true
+  issuerRef:
+    name: "selfsigned-ca-issuer"
+    kind: "ClusterIssuer"
+    group: "cert-manager.io"
+  duration: "168h"      # 7 days — preview env lifetime
+  renewBefore: "24h"
+  algorithm: ECDSA
+  size: 256
+
+externalSecret:
+  enabled: true
+  secretStoreRef:
+    name: "fake-local-store"
+    kind: "ClusterSecretStore"
+  refreshInterval: "5m"
+  data:
+    - secretKey: DATABASE_URL
+      remoteRef:
+        key: hello-world/database/DATABASE_URL
+        version: v1
+
+envFromSecret:
+  enabled: true
+  secretName: ""
+  keys:
+    - DATABASE_URL
+
+env:
+  - name: PORT
+    value: "8080"
+  - name: LOG_LEVEL
+    value: "debug"
+  - name: LOG_FORMAT
+    value: "json"
+  - name: ENVIRONMENT
+    value: "preview"
+  - name: SKIP_MIGRATIONS
+    value: "true"
+  - name: ENABLE_METRICS
+    value: "true"
+  - name: ENABLE_TRACING
+    value: "false"
+  - name: ADMIN_FLAGS_ENABLED
+    value: "false"
+  - name: OTEL_SERVICE_NAME
+    value: "hello-world-preview"

--- a/hello-world/helm/hello-world/values.yaml
+++ b/hello-world/helm/hello-world/values.yaml
@@ -5,6 +5,14 @@ replicaCount: 2
 
 image:
   repository: ghcr.io/your-org/hello-world
+  # Image reference precedence (highest to lowest):
+  #   1. image.digest — sha256 digest, e.g. "sha256:abc123..." (immutable, recommended for prod)
+  #   2. image.tag    — mutable tag, e.g. "v1.2.3" or "sha-<gitsha>"
+  # When image.digest is set (non-empty), the Deployment renders
+  # `repository@digest` and ignores image.tag entirely. CI publishes the
+  # digest after `docker push`; GitOps PRs update image.digest in the
+  # downstream HelmRelease.
+  digest: ""
   tag: "latest"
   pullPolicy: IfNotPresent
 

--- a/hello-world/monitoring/prometheus-rules.yaml
+++ b/hello-world/monitoring/prometheus-rules.yaml
@@ -1,3 +1,21 @@
+# PrometheusRule for hello-world.
+#
+# Two rule groups:
+#   1. hello-world.general — direct symptom alerts (errors, latency, traffic).
+#   2. hello-world.slo     — multi-window multi-burn-rate SLO alerts.
+#
+# SLO target: 99.9% availability over a 30-day window, defined as the
+# fraction of HTTP requests returning 2xx out of all requests. The error
+# budget is therefore 0.1% (= 0.001) over 30 days.
+#
+# Multi-window multi-burn-rate alerting (Google SRE workbook, ch.5):
+#   - Fast burn (page):  2% of monthly budget in 1h    (burn rate 14.4)
+#   - Fast burn (page):  5% of monthly budget in 6h    (burn rate  6.0)
+#   - Slow burn (ticket): 10% of monthly budget in 1d/3d (burn rate 3/1)
+#
+# All alerts carry a `runbook_url` annotation pointing to docs in this
+# repo so on-call has one click to mitigation steps.
+
 groups:
   - name: hello-world.general
     rules:
@@ -12,6 +30,7 @@ groups:
           description: |
             No scrape targets are up for hello-world for more than 2 minutes.
             This usually indicates the service is unavailable or scraping is misconfigured.
+          runbook_url: "https://github.com/100rd/Creme-ala-creme/blob/main/docs/runbooks/HelloWorldTargetDown.md"
 
       - alert: HelloWorldHighErrorRate
         expr: |
@@ -28,6 +47,7 @@ groups:
           description: |
             The proportion of non-2xx responses exceeded 5% over the last 5 minutes.
             Investigate recent deployments, dependencies and upstreams.
+          runbook_url: "https://github.com/100rd/Creme-ala-creme/blob/main/docs/runbooks/HelloWorldHighErrorRate.md"
 
       - alert: HelloWorldHighLatencyP95
         expr: |
@@ -44,6 +64,7 @@ groups:
           description: |
             The 95th percentile latency is above 500ms over the last 5 minutes.
             Check resource saturation and downstream dependencies.
+          runbook_url: "https://github.com/100rd/Creme-ala-creme/blob/main/docs/runbooks/HelloWorldHighLatencyP95.md"
 
       - alert: HelloWorldNoTraffic
         expr: sum(rate(http_requests_total{job=~".*hello-world.*"}[10m])) by (job) == 0
@@ -55,6 +76,7 @@ groups:
           summary: "hello-world has no traffic"
           description: |
             No requests observed for 10 minutes. If this is unexpected, check routing and ingress.
+          runbook_url: "https://github.com/100rd/Creme-ala-creme/blob/main/docs/runbooks/HelloWorldNoTraffic.md"
 
       - alert: HelloWorldMetricsHandlerErrors
         expr: increase(promhttp_metric_handler_errors_total{job=~".*hello-world.*"}[5m]) > 0
@@ -67,5 +89,131 @@ groups:
           description: |
             The metrics endpoint reported encoding/serving errors in the last 10 minutes.
             This may indicate invalid metrics or memory pressure.
+          runbook_url: "https://github.com/100rd/Creme-ala-creme/blob/main/docs/runbooks/HelloWorldMetricsHandlerErrors.md"
 
+  # ---------------------------------------------------------------------------
+  # SLO: 99.9% availability over 30 days.
+  # Error ratio = non-2xx / total. Budget = 1 - SLO = 0.001.
+  # Burn rate = error_ratio / 0.001 = error_ratio * 1000.
+  # ---------------------------------------------------------------------------
+  - name: hello-world.slo
+    rules:
+      # Recording rules: compute error_ratio over multiple windows once,
+      # alert expressions reuse them. Cheaper at evaluation time and easier
+      # to inspect in Prometheus UI.
+      - record: job:hello_world_request_errors:ratio_rate5m
+        expr: |
+          sum(rate(http_requests_total{job=~".*hello-world.*",status!~"2.."}[5m])) by (job)
+          /
+          sum(rate(http_requests_total{job=~".*hello-world.*"}[5m])) by (job)
 
+      - record: job:hello_world_request_errors:ratio_rate30m
+        expr: |
+          sum(rate(http_requests_total{job=~".*hello-world.*",status!~"2.."}[30m])) by (job)
+          /
+          sum(rate(http_requests_total{job=~".*hello-world.*"}[30m])) by (job)
+
+      - record: job:hello_world_request_errors:ratio_rate1h
+        expr: |
+          sum(rate(http_requests_total{job=~".*hello-world.*",status!~"2.."}[1h])) by (job)
+          /
+          sum(rate(http_requests_total{job=~".*hello-world.*"}[1h])) by (job)
+
+      - record: job:hello_world_request_errors:ratio_rate6h
+        expr: |
+          sum(rate(http_requests_total{job=~".*hello-world.*",status!~"2.."}[6h])) by (job)
+          /
+          sum(rate(http_requests_total{job=~".*hello-world.*"}[6h])) by (job)
+
+      - record: job:hello_world_request_errors:ratio_rate1d
+        expr: |
+          sum(rate(http_requests_total{job=~".*hello-world.*",status!~"2.."}[1d])) by (job)
+          /
+          sum(rate(http_requests_total{job=~".*hello-world.*"}[1d])) by (job)
+
+      - record: job:hello_world_request_errors:ratio_rate3d
+        expr: |
+          sum(rate(http_requests_total{job=~".*hello-world.*",status!~"2.."}[3d])) by (job)
+          /
+          sum(rate(http_requests_total{job=~".*hello-world.*"}[3d])) by (job)
+
+      # Fast burn — page on-call.
+      # 2% budget burn in 1h corresponds to burn_rate >= 14.4. We require
+      # BOTH a short (5m) and the long (1h) window to be above the
+      # threshold: the short window prevents alerting on stale data, the
+      # long one prevents alerting on momentary spikes.
+      - alert: HelloWorldSLOBurnFast1h
+        expr: |
+          job:hello_world_request_errors:ratio_rate1h  > (14.4 * 0.001)
+          and
+          job:hello_world_request_errors:ratio_rate5m  > (14.4 * 0.001)
+        for: 2m
+        labels:
+          severity: critical
+          service: hello-world
+          slo: availability-99-9
+          window: 1h
+        annotations:
+          summary: "hello-world fast SLO burn (1h window, 14.4x budget rate)"
+          description: |
+            At the current error rate, the 30-day error budget would be
+            consumed in roughly 2 days. Mitigation should start immediately.
+          runbook_url: "https://github.com/100rd/Creme-ala-creme/blob/main/docs/runbooks/HelloWorldSLOBurnFast.md"
+
+      # 6h window: 5% of monthly budget burn implies burn_rate >= 6.
+      - alert: HelloWorldSLOBurnFast6h
+        expr: |
+          job:hello_world_request_errors:ratio_rate6h  > (6 * 0.001)
+          and
+          job:hello_world_request_errors:ratio_rate30m > (6 * 0.001)
+        for: 15m
+        labels:
+          severity: critical
+          service: hello-world
+          slo: availability-99-9
+          window: 6h
+        annotations:
+          summary: "hello-world fast SLO burn (6h window, 6x budget rate)"
+          description: |
+            Sustained burn over the past 6 hours indicates the monthly
+            error budget will be exhausted within ~5 days.
+          runbook_url: "https://github.com/100rd/Creme-ala-creme/blob/main/docs/runbooks/HelloWorldSLOBurnFast.md"
+
+      # Slow burn — open a ticket, no page.
+      # 10% of monthly budget burn over 1d implies burn_rate >= 3.
+      - alert: HelloWorldSLOBurnSlow1d
+        expr: |
+          job:hello_world_request_errors:ratio_rate1d  > (3 * 0.001)
+          and
+          job:hello_world_request_errors:ratio_rate1h  > (3 * 0.001)
+        for: 1h
+        labels:
+          severity: warning
+          service: hello-world
+          slo: availability-99-9
+          window: 1d
+        annotations:
+          summary: "hello-world slow SLO burn (1d window, 3x budget rate)"
+          description: |
+            Slow but persistent error rate over 24 hours. Budget will be
+            exhausted within ~10 days at this pace. File a ticket and
+            investigate during business hours.
+          runbook_url: "https://github.com/100rd/Creme-ala-creme/blob/main/docs/runbooks/HelloWorldSLOBurnSlow.md"
+
+      - alert: HelloWorldSLOBurnSlow3d
+        expr: |
+          job:hello_world_request_errors:ratio_rate3d  > (1 * 0.001)
+          and
+          job:hello_world_request_errors:ratio_rate6h  > (1 * 0.001)
+        for: 3h
+        labels:
+          severity: warning
+          service: hello-world
+          slo: availability-99-9
+          window: 3d
+        annotations:
+          summary: "hello-world slow SLO burn (3d window, 1x budget rate)"
+          description: |
+            Error rate matches the steady-state budget burn over 3 days.
+            Investigate root cause before the next deploy.
+          runbook_url: "https://github.com/100rd/Creme-ala-creme/blob/main/docs/runbooks/HelloWorldSLOBurnSlow.md"


### PR DESCRIPTION
## Summary

Closes Phase C of 3 — the last three TBD items in the README checklist:

- **Item 3: CI immutability** — Helm `image.digest` precedence, GitOps PR to `100rd/platform-design`, `environment: prod` on the deploy job.
- **Item 5: Alerts & runbooks** — Alertmanager routing (Slack `#oncall` / `#monitoring` / null), inhibit rules, multi-window multi-burn-rate SLO alerts for 99.9% availability over 30 days, per-alert runbook docs.
- **Item 7: Ephemeral envs** — PR-preview workflow with sticky comments, live deploy when `KUBE_CONFIG_B64` is set, `helm template + kubeconform` dry-run otherwise; auto cleanup on PR close.

After this PR the TBD checklist is fully closed:

| Item | Status |
| --- | --- |
| 1. /readyz & /livez + graceful shutdown | x |
| 2. JSON logs with trace ids | x |
| 3. Secrets via ESO / Vault | x |
| 4. CI immutability + GitOps + env approvals | **x (this PR)** |
| 5. HTTPS via cert-manager + smoke tests | x |
| 6. Alerts + runbooks + SLOs | **x (this PR)** |
| 7. RBAC + quotas | x |
| 8. Ephemeral envs + auto cleanup | **x (this PR)** |

## Companion PR

[`100rd/platform-design#232`](https://github.com/100rd/platform-design/pull/232) — adds the `HelmRelease` at `apps/direct/hello-world/helmrelease.yaml` that this repo's `gitops-pr` job will bump on every main-branch push.

## Smoke tests — all 8 PASS

Run against the local `kind-creme` cluster (Phase B's running deployment is the baseline; this PR did not reset the cluster).

| # | Test | Result |
| --- | --- | --- |
| 1 | `promtool check rules hello-world/monitoring/prometheus-rules.yaml` | SUCCESS — 15 rules |
| 2 | `amtool check-config alertmanager/alertmanager.yml` (via `kubectl -n monitoring exec alertmanager-0`) | SUCCESS — 3 receivers, 2 inhibit rules |
| 3 | `helm template` with `image.digest=sha256:...` + `image.tag=v1.2.3` | renders `repo@sha256:...` (digest wins) |
| 4 | `helm template` with `image.tag=v1.2.3` only | renders `repo:v1.2.3` |
| 5 | `amtool alert add` with three severities | `severity=critical` -> `slack-oncall`, `warning` -> `slack-monitoring`, `info` -> `null`. Critical inhibits warning/info for same service |
| 6 | `helm upgrade --install hello-world-pr-999 ... -f values-preview.yaml ...` | Pod 1/1, Certificate Ready, ExternalSecret Synced, ingress returns HTTP 200 on `https://pr-999.hello-world.local/` |
| 7 | `helm uninstall pr-999 -n pr-999 && kubectl delete ns pr-999` | clean teardown, namespace removed |
| 8 | Companion PR open in `platform-design` | https://github.com/100rd/platform-design/pull/232 |

## Files changed (overview)

```
.github/workflows/ci.yml                                    +118  -3
.github/workflows/pr-preview.yml                            +254   (new)
README.md                                                   +118  -8
alertmanager/alertmanager.yml                               +104  -2
docs/runbooks/HelloWorldHighErrorRate.md                    +47    (new)
docs/runbooks/HelloWorldHighLatencyP95.md                   +43    (new)
docs/runbooks/HelloWorldMetricsHandlerErrors.md             +39    (new)
docs/runbooks/HelloWorldNoTraffic.md                        +34    (new)
docs/runbooks/HelloWorldSLOBurnFast.md                      +51    (new)
docs/runbooks/HelloWorldSLOBurnSlow.md                      +48    (new)
docs/runbooks/HelloWorldTargetDown.md                       +51    (new)
docs/runbooks/README.md                                     +22    (new)
hello-world/helm/hello-world/templates/_helpers.tpl         +20    (digest helper)
hello-world/helm/hello-world/templates/deployment.yaml      +1   -1 (use helper)
hello-world/helm/hello-world/values.yaml                    +9   -0 (image.digest field)
hello-world/helm/hello-world/values-preview.yaml            +110   (new)
hello-world/monitoring/prometheus-rules.yaml                +135  -1 (SLO + runbook_url)
```

5 commits, conventional commit style.

## Required follow-up actions for the user

These cannot be automated from inside the PR; they need to be configured by an org admin in the GitHub UI:

1. **Create the `prod` environment** at https://github.com/100rd/Creme-ala-creme/settings/environments
   - Add required reviewers (the on-call engineer(s)) so the `deploy` job pauses for manual approval.
2. **Add the `PLATFORM_DESIGN_TOKEN` secret** at https://github.com/100rd/Creme-ala-creme/settings/secrets/actions
   - Fine-grained PAT with **PR write + contents write** on `100rd/platform-design` ONLY.
   - Until this is set, the `gitops-pr` job logs a warning and exits cleanly (does not break the pipeline).
3. **Optional: add `KUBE_CONFIG_B64`** at the same secrets page to enable live PR previews.
   - Until this is set, the PR-preview workflow runs dry-run only (helm template + kubeconform, no cluster contact).
4. **Merge the companion platform-design PR** (https://github.com/100rd/platform-design/pull/232) so the next bump target exists.

## Test plan

- [x] `helm lint hello-world/helm/hello-world` — clean
- [x] `helm template` + `kubeconform -strict` — 12 valid resources, 0 errors
- [x] `promtool check rules` — SUCCESS, 15 rules
- [x] `amtool check-config` — SUCCESS, against running Alertmanager pod
- [x] End-to-end install of preview overlay to `pr-999` namespace — pod Ready, Cert Ready, ESO Synced, HTTP 200 on ingress
- [x] End-to-end teardown — namespace fully gone in <30s
- [x] Companion PR open in platform-design
- [ ] After merge: configure prod environment + PLATFORM_DESIGN_TOKEN, then verify next main push opens an automated platform-design PR